### PR TITLE
fix: Space in EditorCofig wasn't parsing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,6 @@ insert_final_newline = false
 indent_style = tab
 indent_size = 4
 
-[{.*,*.json,*.md, *.yml}]
+[{.*,*.json,*.md,*.yml}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION

The space in the selector ment that it wasn't being read/enforced